### PR TITLE
Fix Cenote summary path wildcard

### DIFF
--- a/sbx_cenote_taker.smk
+++ b/sbx_cenote_taker.smk
@@ -35,7 +35,6 @@ rule cenote_taker:
         summary=VIRUS_FP
         / "cenote_taker"
         / "{sample}"
-        / "{sample}"
         / "{sample}_CONTIG_SUMMARY.tsv",
     benchmark:
         BENCHMARK_FP / "cenote_taker_{sample}.tsv"
@@ -86,7 +85,6 @@ rule filter_cenote_contigs:
         contigs=VIRUS_FP / "cenote_taker" / "{sample}" / "final.contigs.fasta",
         summary=VIRUS_FP
         / "cenote_taker"
-        / "{sample}"
         / "{sample}"
         / "{sample}_CONTIG_SUMMARY.tsv",
     output:


### PR DESCRIPTION
## Summary
- remove the duplicated sample directory from the Cenote-Taker summary outputs
- align the filter rule inputs with the corrected path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690d0a432f3c832380aa4563730d6b91