### PR TITLE
Rename filtered cenote output path to avoid DAG cycle

### DIFF
--- a/sbx_cenote_taker.smk
+++ b/sbx_cenote_taker.smk
@@ -11,7 +11,7 @@ def get_extension_path() -> Path:
 
 
 def cenote_output() -> Path:
-    return VIRUS_FP / "cenote_taker" / "{sample}.fasta"
+    return VIRUS_FP / "cenote_taker" / "filtered" / "{sample}.fasta"
 
 
 rule all_cenote_taker:
@@ -90,7 +90,7 @@ rule filter_cenote_contigs:
         / "{sample}"
         / "{sample}_CONTIG_SUMMARY.tsv",
     output:
-        VIRUS_FP / "cenote_taker" / "{sample}.fasta",
+        cenote_output(),
     params:
         include_phages=Cfg["sbx_cenote_taker"]["include_phages"],
     script:


### PR DESCRIPTION
## Summary
- update the cenote output path to write filtered FASTA files to a dedicated subdirectory
- reuse the cenote_output helper for the filter rule output to keep downstream inputs consistent and avoid self-dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bada07e4c8323b652cf51e382b801)